### PR TITLE
reduce image size

### DIFF
--- a/OracleSOA/README.md
+++ b/OracleSOA/README.md
@@ -61,6 +61,8 @@ If you want to run the container on a remote server for later access it, or if y
     $ sudo docker inspect --format '{{ .NetworkSettings.IPAddress }}' soahost
     xxx.xx.x.xx
 
+Alternatively, if you are running on boot2docker, the ip address is obtained by executing `boot2docker ip`.
+ 
 Now you can access the AdminServer Web Console at [http://xxx.xx.x.xx:7001/console](http://xxx.xx.x.xx:7001/console).
 
 For more information on how to bind ports, check the Docker Network documentation.

--- a/OracleSOA/dockerfiles/12.1.3/Dockerfile.developer
+++ b/OracleSOA/dockerfiles/12.1.3/Dockerfile.developer
@@ -54,7 +54,7 @@ RUN mkdir /u01 && chmod a+xr /u01 && \
     useradd -b /u01 -m -s /bin/bash oracle
 
 # Copy packages
-COPY $SOA_ZIP /u01/
+ADD $SOA_ZIP /u01/
 COPY $JAVA_RPM /u01/
 COPY install.file /u01/
 COPY oraInst.loc /u01/
@@ -75,18 +75,17 @@ RUN echo "net.core.rmem_max=4192608" > /u01/oracle/.sysctl.conf && \
     echo "net.core.wmem_max=4192608" >> /u01/oracle/.sysctl.conf && \ 
     sysctl -e -p /u01/oracle/.sysctl.conf
 
-# Adjust file permissions, go to /u01 as user 'oracle' to proceed with SOA Suite installation
-RUN chown oracle:oracle -R /u01
-
 # Unzip SOA Suite installer
 WORKDIR /u01
-RUN jar xf $SOA_ZIP
 
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with SOA Suite installation
 # Installation of SOA Suite 
-RUN mkdir /u01/oracle/.inventory
-RUN chown oracle:oracle -R /u01/oracle/.inventory
-RUN su oracle -c "java -jar $SOA_PKG -ignoreSysPrereqs -novalidation -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME" && \
-    rm $SOA_PKG $SOA_PKG2 $SOA_ZIP /u01/oraInst.loc /u01/install.file
+# Remove packages
+RUN mkdir /u01/oracle/.inventory && \
+chown oracle:oracle -R /u01 && \
+jar xf $SOA_ZIP && \
+su oracle -c "java -jar $SOA_PKG -ignoreSysPrereqs -novalidation -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME" && \
+rm $SOA_PKG $SOA_PKG2 /u01/$SOA_ZIP /u01/oraInst.loc /u01/install.file
 
 WORKDIR /u01/oracle/
 


### PR DESCRIPTION
Hi Jorge,

Sorry for the confusion I have created. I have done the following changes:
1. Add a note in case you are using boot2docker
2. Merge some RUN commands to reduce the size of the image. I think some more improvements can be done. The image size has dropped to 7.8GB instead of 14GB.

With your version I faced `no space left` issue because my boot2docker images was small, so after I resized I saw the size went up to 14GB. Have you seen that in your machine?

Let me know if you want me to do some more testing.

Cheers,
Jorge
